### PR TITLE
Merging windows_builds and main

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Semisight Studios
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Rotaze
+Rotaze is a 2D maze-based platformer game where one must move a ball from point A to point B. However, instead of moving the ball you play as, you control the maze by rotating it. The ball is affected by gravity, meaning that the only way to move the ball to the goal is by rotating the maze to certain angles in which the ball will then roll in that direction.
+
+## How to Download and Play
+Do not download the raw repository files. Instead, look at the **Releases** section on the right side of this page and click on the .zip file at the top.\
+This game is not currently available for console or mobile users. When support for console and mobile is added, you will download Rotaze from your device's game/app store rather than from this Github page.
+Speaking of unsupported platforms, Rotaze currently does not have support for Mac or Linux. When support for Mac and Linux is added, there will be separate branches to this repository dedicated to these platforms.
+
+## System Requirements
+**CPU**: Any standard dual-core Intel/AMD processor released after 2005\`*
+
+**Memory**: 4 Gigabytes or more\`
+
+**Platforms**: Windows 7 (64-Bit)\*\, Windows 10 (64-Bit)\*\, Windows 11 (64-Bit)\^
+
+**Storage**: 128 Megabytes or more
+
+**GPU**: DirectX 10/11/12 compatible\`
+
+**Monitor**: Any landscape 16:9 monitor above or equal to 720p\^
+<details>
+  <summary>Click for more info</summary>
+  NOTE: Some of the system requirements listed here are guesses based on observed data via Task Manager. They may be inaccurate
+
+\* Tested on a virtual machine\
+\^ Tested natively on real, physical hardware\
+\` Minimum baseline requirement dictated by the underlying Unity Engine
+
+Effective as of 0.0.6a</details>
+
+## License & Modding
+This project is licensed under the **MIT License**. You are completely free to modify, break, or build upon this game. Just make sure to keep the copyright credit to **Semisight Studios** intact.


### PR DESCRIPTION
I've thought of a better way to let users select what platform they are using, so I'm getting rid of the idea of one branch for each platform (making a windows_builds branch, a mac_builds branch and a linux_builds branch) and letting players can choose to download the Windows files zipped together, the Linux files zipped together, or the Mac .app file from the assets page of each GitHub Release, which, friendly reminder, there will be one GitHub Release made whenever I release an update for Rotaze.